### PR TITLE
removed 'COPY version' line 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ ENV PATH /node_modules/bids-validator/bin:$PATH
 
 COPY run.py /run.py
 
-COPY version /version
+#COPY version /version
 
 ENTRYPOINT ["/run.py"]


### PR DESCRIPTION

commented out 'COPY version' line from `Dockerfile` because there is no file named version here so errors when building container

this completes ok after running the lines in `Makefile` 

`docker build -t pnl-example . `

`docker run -i --rm -v ${PWD}:/example pnl-example -j /example/example.json -s /example/stimulus.tsv`

Output:

```
using model spec from: /example/example.json
found node: Color
found node: Decision
found node: Motion
[[array([0.65655963]), array([0.98279813])], [array([0.92301252]), 
array([0.75175546])],[array([0.65655963]), array([0.98279813])]]
```

